### PR TITLE
Fix multi_highlight_example on Python3.

### DIFF
--- a/examples/multi_highlight_example.py
+++ b/examples/multi_highlight_example.py
@@ -44,7 +44,7 @@ class MultiHighlight(mpldatacursor.HighlightingDataCursor):
         """
         # Two-way lookup table
         self.artist_map = dict(paired_artists)
-        self.artist_map.update([pair[::-1] for pair in paired_artists])
+        self.artist_map.update([pair[::-1] for pair in self.artist_map.items()])
 
         kwargs['display'] = 'single'
         artists = self.artist_map.values()


### PR DESCRIPTION
On Python3 zip returns an iterator, so the earlier

    self.artist_map.update([pair[::-1] for pair in paired_artists])

had no effect.  Replace by iterating on the new dict itself.