### PR TITLE
artist.contains should check canvas identity...

### DIFF
--- a/mpldatacursor/datacursor.py
+++ b/mpldatacursor/datacursor.py
@@ -659,7 +659,7 @@ class DataCursor(object):
             """Need to ensure we don't trigger a pick event for axes in a
             different figure. Otherwise, picking on one figure will trigger a
             datacursor in another figure."""
-            if event.inaxes is artist.axes:
+            if event.canvas is artist.figure.canvas:
                 return artist.contains(event)
             else:
                 return False, {}


### PR DESCRIPTION
... instead of axes identity.  An annotation can end up outside of the
axes, and we want to still be able to delete it by right clicking on it,
even though the click itself will be out of the axes.

cf. second half of #68.