### PR TITLE
Fix formatting for MPL 3.3.0+

### DIFF
--- a/mpldatacursor/datacursor.py
+++ b/mpldatacursor/datacursor.py
@@ -409,8 +409,14 @@ class DataCursor(object):
             formatter.axis = axis
             formatter._set_format()
             formatter._set_order_of_magnitude()
+        
+        try:
+            # Again, older versions of mpl
+            return formatter.pprint_val(x)
+        except AttributeError:
+            # 3.3.0 or later
+            return formatter.format_data_short(x)
 
-        return formatter.pprint_val(x)
 
     def annotate(self, ax, **kwargs):
         """


### PR DESCRIPTION
I tried to fix the error from using pprint_val which was removed from the latest version of matplotlib.
Fixes #97 