### PR TITLE
Fix syntax warning about "is not" vs "!="

### DIFF
--- a/mpldatacursor/datacursor.py
+++ b/mpldatacursor/datacursor.py
@@ -199,7 +199,7 @@ class DataCursor(object):
 
         self._annotation_kwargs = kwargs
         self.annotations = {}
-        if self.display is not 'multiple':
+        if self.display != 'multiple':
             for ax in self.axes:
                 self.annotations[ax] = self.annotate(ax, **kwargs)
                 # Hide the annotation box until clicked...


### PR DESCRIPTION
I am using Python 3.8 and got a warning:
`/usr/local/lib/python3.8/dist-packages/mpldatacursor-0.7.dev0-py3.8.egg/mpldatacursor/datacursor.py:202: SyntaxWarning: "is not" with a literal. Did you mean "!="?`

This was easy to fix so here is a pull request!